### PR TITLE
Add matmul with float16

### DIFF
--- a/gpu.h
+++ b/gpu.h
@@ -318,6 +318,9 @@ struct KernelCode {
                     const Shape &workgroupSize = {256, 1, 1},
                     NumType precision = kf32)
       : data(pData), workgroupSize(workgroupSize), precision(precision) {
+    if (precision == kf16) {
+      data = "enable f16;\n" + data;
+    }
     replaceAll(data, "{{workgroupSize}}", toString(workgroupSize));
     replaceAll(data, "{{precision}}", toString(precision));
     LOG(kDefLog, kInfo, "Shader code:\n%s", data.c_str());


### PR DESCRIPTION
This PR implements matrix multiplication with float16.
~~Mac's memory bandwidth is not enough for maximum floating point performance of the GPU. 
To improve performance, we need to reduce memory traffic.~~
https://github.com/AnswerDotAI/gpu.cpp/issues/40#issuecomment-2270142354

The result on M2 pro is as follows:

| Matmul version | GFLOPS|
|----------------|----------|
| 2D Matmul with float32(version = 8)| 1672.18 GFLOPS|
| Transposed 2D Matrix with float32(version = 9)| 1702.70 GFLOPS|
|  2D Matmul with float16(version = 10)| 3174.96 GFLOPS|
|  Transposed 2D Matmul with float16(version = 11)| 2889.82 GFLOPS|