### PR TITLE
Using FetchContent to fetch libdawn.dylib from github when library not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,14 @@ source
 third_party/lib/libdawn.*
 third_party/lib/*.so
 third_party/lib/*.dylib
+
+# formatter files
+.cmake-format.py
+
+# cmake generated files
+compile_commands.json
+out
+
+# clangd files
+.cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,14 +9,16 @@ source
 third_party/lib/libdawn.*
 third_party/lib/*.so
 third_party/lib/*.dylib
+third_party/local/*
 
 # formatter files
 .cmake-format.py
 
-# cmake generated files
-compile_commands.json
+# cmake build directories
 out
+build
 
 # clangd files
 .cache
+compile_commands.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,37 +3,44 @@ project(gpu)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/webgpu.cmake")
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # export compile_commands.json to use with LSP
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # export compile_commands.json to use with
+                                      # LSP
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(USE_LOCAL_LIBS "Use local libraries instead of fetching from the internet" OFF)
+option(USE_LOCAL_LIBS
+       "Use local libraries instead of fetching from the internet" OFF)
 
 # Ensure the build type is set
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build: Debug or Release" FORCE)
+    set(CMAKE_BUILD_TYPE
+        Release
+        CACHE STRING "Choose the type of build: Debug or Release" FORCE)
 endif()
 
 option(FASTBUILD "Option to enable fast builds" OFF)
 if(FASTBUILD)
-  set(CMAKE_BUILD_TYPE None)  # Avoid default flags of predefined build types
-  set(CMAKE_CXX_FLAGS "-O0")
+    set(CMAKE_BUILD_TYPE None) # Avoid default flags of predefined build types
+    set(CMAKE_CXX_FLAGS "-O0")
 endif()
 
 option(DEBUG "Option to enable debug flags" OFF)
 if(DEBUG)
-  set(CMAKE_BUILD_TYPE Debug)
-  set(CMAKE_CXX_FLAGS "-O0 -g")
+    set(CMAKE_BUILD_TYPE Debug)
+    set(CMAKE_CXX_FLAGS "-O0 -g")
 endif()
 
 if(WIN64)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWEBGPU_BACKEND_DAWN")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWEBGPU_BACKEND_DAWN")
 endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/gpu.cmake")
 
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
-message(STATUS "Include directories for wgpu: ${CMAKE_CURRENT_SOURCE_DIR}/third_party/headers")
+message(
+    STATUS
+        "Include directories for wgpu: ${CMAKE_CURRENT_SOURCE_DIR}/third_party/headers"
+)
 
 add_library(gpud SHARED gpu.h)
 set_target_properties(gpud PROPERTIES LINKER_LANGUAGE CXX)

--- a/cmake/example.cmake
+++ b/cmake/example.cmake
@@ -1,4 +1,5 @@
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # export compile_commands.json to use with LSP
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # export compile_commands.json to use with
+                                      # LSP
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -9,37 +10,47 @@ get_filename_component(PROJECT_ROOT ${PROJECT_ROOT} DIRECTORY)
 set(FILEPATH_CURRENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
 set(FILEPATH_PROJECT_ROOT "${PROJECT_ROOT}/${FILENAME}")
 
+# Include file finding utility script
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/find_gpu.cmake")
+
 # Check if the file exists in the current directory
-if(EXISTS ${FILEPATH_CURRENT_DIR})
-    set(TARGET_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-elseif(EXISTS ${FILEPATH_PROJECT_ROOT})
-    set(TARGET_FILE_PATH ${PROJECT_ROOT})
-else()
-    message(FATAL_ERROR "File ${FILENAME} not found in either ${CMAKE_CURRENT_SOURCE_DIR} or ${CMAKE_CURRENT_SOURCE_DIR}/../../")
+find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${FILEPATH_CURRENT_DIR}
+                  ${TARGET_FILE_PATH})
+if("${TARGET_FILE_PATH}" STREQUAL "")
+    find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_ROOT}
+                      ${TARGET_FILE_PATH})
+    if("${TARGET_FILE_PATH}" STREQUAL "")
+        message(
+            FATAL_ERROR
+                "File ${FILENAME} not found in either ${CMAKE_CURRENT_SOURCE_DIR} or ${CMAKE_CURRENT_SOURCE_DIR}/../../"
+        )
+    endif()
 endif()
 
 # Ensure the build type is set
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build: Debug or Release" FORCE)
+    set(CMAKE_BUILD_TYPE
+        Release
+        CACHE STRING "Choose the type of build: Debug or Release" FORCE)
 endif()
 
 # Define architecture and build type directories or file names
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(ARCH "x64")
+    set(ARCH "x64")
 else()
-  set(ARCH "x86")
+    set(ARCH "x86")
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(BUILD_TYPE "Debug")
+    set(BUILD_TYPE "Debug")
 else()
-  set(BUILD_TYPE "Release")
+    set(BUILD_TYPE "Release")
 endif()
 
 if(NOT TARGET gpu)
-  message(STATUS "GPU_LIB not found")
-  include("${TARGET_FILE_PATH}/cmake/webgpu.cmake")
-  include("${TARGET_FILE_PATH}/cmake/gpu.cmake")
+    message(STATUS "GPU_LIB not found")
+    include("${TARGET_FILE_PATH}/cmake/webgpu.cmake")
+    include("${TARGET_FILE_PATH}/cmake/gpu.cmake")
 endif()
 
 add_executable(${PROJECT_NAME} run.cpp)
@@ -48,9 +59,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE wgpu)
 target_link_libraries(${PROJECT_NAME} PRIVATE webgpu)
 
 if(WIN32)
-# Ensure DLL is copied if on Windows
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                   ${DLL_PATH}
-                   $<TARGET_FILE_DIR:${PROJECT_NAME}>)
+    # Ensure DLL is copied if on Windows
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DLL_PATH}
+                $<TARGET_FILE_DIR:${PROJECT_NAME}>)
 endif()

--- a/cmake/example.cmake
+++ b/cmake/example.cmake
@@ -14,11 +14,11 @@ set(FILEPATH_PROJECT_ROOT "${PROJECT_ROOT}/${FILENAME}")
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/find_gpu.cmake")
 
 # Check if the file exists in the current directory
-find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${FILEPATH_CURRENT_DIR}
-                  ${TARGET_FILE_PATH})
+find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${FILENAME}
+                  TARGET_FILE_PATH)
 if("${TARGET_FILE_PATH}" STREQUAL "")
-    find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_ROOT}
-                      ${TARGET_FILE_PATH})
+    find_project_root(${FILEPATH_CURRENT_DIR} ${FILENAME}
+                      TARGET_FILE_PATH)
     if("${TARGET_FILE_PATH}" STREQUAL "")
         message(
             FATAL_ERROR

--- a/cmake/find_gpu.cmake
+++ b/cmake/find_gpu.cmake
@@ -1,0 +1,30 @@
+# file name to find
+set(FILENAME "gpu.h")
+
+# Function to check for file existence up the directory hierarchy
+function(find_project_root current_dir filename result_var)
+    set(found FALSE) # Flag to indicate if the file is found
+    set(current_check_dir "${current_dir}") # Start from the given directory
+    # using 1 is jsut to supress the cmane-format warning
+    foreach(i RANGE 0 2 1)
+        set(filepath "${current_check_dir}/${filename}")
+
+        if(EXISTS "${filepath}")
+            set(${result_var}
+                "${current_check_dir}"
+                PARENT_SCOPE)
+            set(found TRUE)
+            break()
+        endif()
+
+        # Move one level up
+        get_filename_component(current_check_dir "${current_check_dir}"
+                               DIRECTORY)
+    endforeach()
+
+    if(NOT found)
+        set(${result_var}
+            ""
+            PARENT_SCOPE) # Set to empty if not found
+    endif()
+endfunction()

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -61,9 +61,14 @@ else()
         # if not found, try download from release
     else()
         message("libdawn not found, try downloading from the release")
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            set(libdawn_ext "dylib")
+        elseif(UNIX)
+            set(libdawn_ext "so")
+        endif()
         FetchContent_Declare(
             libdawn
-            URL https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.dylib
+            URL https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.${libdawn_ext}
             DOWNLOAD_NO_EXTRACT TRUE
             SOURCE_DIR "${TARGET_FILE_PATH}/third_party/lib")
         FetchContent_MakeAvailable(libdawn)

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -64,8 +64,8 @@ else()
         FetchContent_Declare(
             libdawn
             URL https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.dylib
-                DOWNLOAD_DIR
-                "${TARGET_FILE_PATH}/third_party/lib")
+            DOWNLOAD_NO_EXTRACT TRUE
+            SOURCE_DIR "${TARGET_FILE_PATH}/third_party/lib")
         FetchContent_MakeAvailable(libdawn)
         find_library(LIBDAWN dawn REQUIRED
                      PATHS "${TARGET_FILE_PATH}/third_party/lib")

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -58,6 +58,7 @@ else()
         message(STATUS "Found libdawn: ${LIBDAWN}")
         # Link against libdawn
         target_link_libraries(webgpulib INTERFACE ${LIBDAWN})
+        # if not found, try download from release
     else()
         message(
             FATAL_ERROR "libdawn not found, try downloading from the release")
@@ -67,13 +68,14 @@ else()
                 DOWNLOAD_DIR
                 "${TARGET_FILE_PATH}/third_party/lib")
         FetchContent_MakeAvailable(libdawn)
-    find_library(LIBDAWN dawn REQUIRED PATHS "${TARGET_FILE_PATH}/third_party/lib")
+        find_library(LIBDAWN dawn REQUIRED
+                     PATHS "${TARGET_FILE_PATH}/third_party/lib")
         if(LIBDAWN)
             message(STATUS "Found libdawn: ${LIBDAWN}")
             # Link against libdawn
             target_link_libraries(webgpulib INTERFACE ${LIBDAWN})
         else()
-            message(
-                FATAL_ERROR "libdawn not found")
+            message(FATAL_ERROR "libdawn not found")
         endif()
+    endif()
 endif()

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -63,7 +63,7 @@ else()
         message("libdawn not found, try downloading from the release")
         FetchContent_Declare(
             libdawn
-            url https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.dylib
+            URL https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.dylib
                 DOWNLOAD_DIR
                 "${TARGET_FILE_PATH}/third_party/lib")
         FetchContent_MakeAvailable(libdawn)

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -67,13 +67,13 @@ else()
                 DOWNLOAD_DIR
                 "${TARGET_FILE_PATH}/third_party/lib")
         FetchContent_MakeAvailable(libdawn)
-        find_library(LIBDAWN dawn PATHS "${TARGET_FILE_PATH}/third_party/lib")
-    if(LIBDAWN)
-        message(STATUS "Found libdawn: ${LIBDAWN}")
-        # Link against libdawn
-        target_link_libraries(webgpulib INTERFACE ${LIBDAWN})
-            else()
-        message(
-            FATAL_ERROR "libdawn not found")
-    endif()
+    find_library(LIBDAWN dawn REQUIRED PATHS "${TARGET_FILE_PATH}/third_party/lib")
+        if(LIBDAWN)
+            message(STATUS "Found libdawn: ${LIBDAWN}")
+            # Link against libdawn
+            target_link_libraries(webgpulib INTERFACE ${LIBDAWN})
+        else()
+            message(
+                FATAL_ERROR "libdawn not found")
+        endif()
 endif()

--- a/cmake/gpu.cmake
+++ b/cmake/gpu.cmake
@@ -60,8 +60,7 @@ else()
         target_link_libraries(webgpulib INTERFACE ${LIBDAWN})
         # if not found, try download from release
     else()
-        message(
-            FATAL_ERROR "libdawn not found, try downloading from the release")
+        message("libdawn not found, try downloading from the release")
         FetchContent_Declare(
             libdawn
             url https://github.com/austinvhuang/dawn-artifacts/releases/download/prerelease/libdawn.dylib

--- a/cmake/webgpu.cmake
+++ b/cmake/webgpu.cmake
@@ -8,47 +8,54 @@ get_filename_component(PROJECT_ROOT ${PROJECT_ROOT} DIRECTORY)
 set(FILEPATH_CURRENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}")
 set(FILEPATH_PROJECT_ROOT "${PROJECT_ROOT}/${FILENAME}")
 
+# Include file finding utility script
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/find_gpu.cmake")
+
 # Check if the file exists in the current directory
-if(EXISTS ${FILEPATH_CURRENT_DIR})
-    set(TARGET_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-elseif(EXISTS ${FILEPATH_PROJECT_ROOT})
-    set(TARGET_FILE_PATH ${PROJECT_ROOT})
-else()
-    message(FATAL_ERROR "File ${FILENAME} not found in either ${CMAKE_CURRENT_SOURCE_DIR} or ${CMAKE_CURRENT_SOURCE_DIR}/../../")
+find_project_root(${CMAKE_CURRENT_SOURCE_DIR} ${FILENAME} TARGET_FILE_PATH)
+if("${TARGET_FILE_PATH}" STREQUAL "")
+    find_project_root(${FILEPATH_CURRENT_DIR} ${FILENAME} TARGET_FILE_PATH)
+    if("${TARGET_FILE_PATH}" STREQUAL "")
+        message(
+            FATAL_ERROR
+                "File ${FILENAME} not found in either ${CMAKE_CURRENT_SOURCE_DIR} or ${CMAKE_CURRENT_SOURCE_DIR}/../../"
+        )
+    endif()
 endif()
 
 include(FetchContent)
 
 set(FETCHCONTENT_BASE_DIR "${TARGET_FILE_PATH}/third_party/fetchcontent")
-set(WEBGPU_DIST_LOCAL_PATH "${TARGET_FILE_PATH}/third_party/local/WebGPU-distribution")
+set(WEBGPU_DIST_LOCAL_PATH
+    "${TARGET_FILE_PATH}/third_party/local/WebGPU-distribution")
 
 if(USE_LOCAL_LIBS)
-  set(WEBGPU_DIST_GIT_REPO ${WEBGPU_DIST_LOCAL_PATH})
-  message(STATUS "Using local WebGPU distribution: ${WEBGPU_DIST_LOCAL_PATH}")
+    set(WEBGPU_DIST_GIT_REPO ${WEBGPU_DIST_LOCAL_PATH})
+    message(STATUS "Using local WebGPU distribution: ${WEBGPU_DIST_LOCAL_PATH}")
 else()
-  set(WEBGPU_DIST_GIT_REPO "https://github.com/eliemichel/WebGPU-distribution")
+    set(WEBGPU_DIST_GIT_REPO
+        "https://github.com/eliemichel/WebGPU-distribution")
 endif()
 
 option(WEBGPU_TAG "WebGPU distribution tag to use")
-if (NOT WEBGPU_TAG)
-  set(WEBGPU_TAG "dawn")
+if(NOT WEBGPU_TAG)
+    set(WEBGPU_TAG "dawn")
 endif()
 message(STATUS "Using WebGPU distribution tag: ${WEBGPU_TAG}")
 
-if (WEBGPU_TAG STREQUAL "dawn")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWEBGPU_BACKEND_DAWN")
-  # use specific commit
-  # set(WEBGPU_TAG "1025b977e1927b6d0327e67352f90feb4bcf8274")
-  # set(WEBGPU_TAG "acf972b7b909f52e183bdae3971b93bb13d4a29e")
-  # add_compile_options(-UABSL_INTERNAL_AT_LEAST_CXX20)
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -UABSL_INTERNAL_AT_LEAST_CXX20")
-  message(STATUS "Using Dawn backend")
+if(WEBGPU_TAG STREQUAL "dawn")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWEBGPU_BACKEND_DAWN")
+    # use specific commit set(WEBGPU_TAG
+    # "1025b977e1927b6d0327e67352f90feb4bcf8274") set(WEBGPU_TAG
+    # "acf972b7b909f52e183bdae3971b93bb13d4a29e")
+    # add_compile_options(-UABSL_INTERNAL_AT_LEAST_CXX20) set(CMAKE_CXX_FLAGS
+    # "${CMAKE_CXX_FLAGS} -UABSL_INTERNAL_AT_LEAST_CXX20")
+    message(STATUS "Using Dawn backend")
 endif()
 
 FetchContent_Declare(
-  webgpu
-  GIT_REPOSITORY  ${WEBGPU_DIST_GIT_REPO}
-  GIT_TAG        ${WEBGPU_TAG}
-  GIT_SHALLOW    TRUE
-)
+    webgpu
+    GIT_REPOSITORY ${WEBGPU_DIST_GIT_REPO}
+    GIT_TAG ${WEBGPU_TAG}
+    GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(webgpu)


### PR DESCRIPTION
This enables the project to be fetched with cmake FetchContent and to be directly built with cmake without calling the python script.

Solution to [this](https://github.com/AnswerDotAI/gpu.cpp/issues/42) issue