### PR TITLE
Fix emscripten deviceLostCallbackInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@ examples/raymarch/build/*
 docs/html
 source
 .DS_Store
-third_party/lib/libdawn.*
-third_party/lib/*.so
-third_party/lib/*.dylib
+third_party/lib/*
 third_party/local/*
 
 # formatter files

--- a/gpu.h
+++ b/gpu.h
@@ -755,7 +755,7 @@ inline Context createContext(const WGPUInstanceDescriptor &desc = {},
       devData.device = device;
       devData.requestEnded = true;
     };
-#ifdef WEBGPU_BACKEND_DAWN
+#if defined(WEBGPU_BACKEND_DAWN) && !defined(__EMSCRIPTEN__)
     devDescriptor.deviceLostCallbackInfo = {
         .callback =
             [](WGPUDevice const *device, WGPUDeviceLostReason reason,


### PR DESCRIPTION
Found out this is available in the native headers but not the emscripten headers. This PR checks for and excludes the callback if emscripten. 

https://github.com/eliemichel/WebGPU-Cpp/blob/main/emscripten/webgpu.hpp

vs

https://github.com/eliemichel/WebGPU-Cpp/blob/main/dawn/webgpu.h