### PR TITLE
Logger Fixes for Windows

### DIFF
--- a/gpu.h
+++ b/gpu.h
@@ -647,7 +647,7 @@ inline TensorPool::~TensorPool() {
 
 /**
  * @brief Checks a condition and logs an error message if the condition is
- * false. In debug mode, it will also exit the program with an error code.
+ * false.
  * @param[in] condition The condition to check.
  * @param[in] message The error message to log if the condition is false.
  * @param[in] file The source file where the check is performed.
@@ -658,7 +658,6 @@ inline void check(bool condition, const char *message,
                   const char *file = "unkown", int line = -1) {
   if (!condition) {
     LOG(kDefLog, kError, "Error in file %s line %d:\n%s", file, line, message);
-    exit(1);
   } else {
     LOG(kDefLog, kTrace, "Success in file %s line %d:\n%s", file, line,
         message);

--- a/utils/logging.h
+++ b/utils/logging.h
@@ -1,75 +1,110 @@
 #ifndef LOGGING_H
 #define LOGGING_H
 
-#include <cstdio>
+#include <iostream>
+#include <sstream>
 #include <cstdarg>
+#include <memory>
 
-namespace gpu {
+namespace gpu
+{
+  enum LogLevel
+  {
+    kNone = 0,
+    kError = 1,
+    kWarn = 2,
+    kInfo = 3,
+    kTrace = 4
+  };
 
-enum LogLevel { kError = 0, kWarn = 1, kInfo = 2, kTrace = 3 };
+  static const char *kLevelStr[] = {"none", "error", "warn", "info", "trace"};
 
-static const char *kLevelStr[] = {"error", "warn", "info", "trace"};
+  /**
+   * @brief Logger struct for logging messages.
+   * stream: The stream to log to.
+   * level: The log level to log messages at.
+   */
+  struct Logger
+  {
+    std::ostream &stream;
+    int level;
+  };
 
-/**
- * @brief Logger struct for logging messages.
- * stream: The stream to log to.
- * buffer: A buffer to store the formatted message.
- * level: The log level to log messages at.
- */
-struct Logger {
-  FILE *stream;
-  char buffer[32768]; // TODO(avh): Expand as needed or fail gracefully.
-  int level;
-};
-
-#ifndef NDEBUG
-/**
- * @brief Log a message to the logger. If NDEBUG is defined in a source or as a
- * compiler flag, this is a no-op.
- *
- * @param logger The logger to log to.
- * @param level The log level of the message.
- * @param message The message to log.
- */
-inline void LOG(Logger& logger, int level, const char *message, ...) {
-  static const char *orange = "\033[0;33m";
-  static const char *red = "\033[0;31m";
-  static const char *white = "\033[0;37m";
-  static const char *gray = "\033[0;90m";
-  static const char *reset = "\033[0m";
-  static const char *logColors[] = {red, red, orange, gray};
-  if (level <= logger.level) {
-    va_list(args);
-    va_start(args, message);
-    snprintf(logger.buffer, sizeof(logger.buffer), message, args);
-    // Brackets and messages are white.
-    // Log levels are red for error and warning, orange for info, and grey for trace.
-    // Then the color is reset.
-    fprintf(logger.stream, "%s[%s%s%s] ", white, logColors[level], kLevelStr[level],
-            white);
-    vfprintf(logger.stream, message, args);
-    fprintf(logger.stream, "%s\n", reset);
-    va_end(args);
+  template <typename T>
+  inline std::string toString(const T &value)
+  {
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
   }
-}
+
+#ifndef NO_LOG
+  /**
+   * @brief Log a message to the logger. If NDEBUG is defined in a source or as a
+   * compiler flag, this is a no-op.
+   *
+   * @param logger The logger to log to.
+   * @param level The log level of the message.
+   * @param message The message to log.
+   */
+  template <typename... Args>
+  inline void LOG(Logger &logger, int level, const char *message, ...)
+  {
+    static const char *orange = "\033[0;33m";
+    static const char *red = "\033[0;31m";
+    static const char *white = "\033[0;37m";
+    static const char *gray = "\033[0;90m";
+    static const char *reset = "\033[0m";
+    static const char *logColors[] = {red, red, orange, gray};
+    if (level <= logger.level)
+    {
+      va_list args;
+      va_start(args, message);
+
+      int size = vsnprintf(nullptr, 0, message, args) + 1;
+      std::unique_ptr<char[]> buffer(new char[size]);
+
+#ifdef _WIN32
+      _vsnprintf_s(buffer.get(), size, _TRUNCATE, message, args);
 #else
-#define LOG(logger, level, message, ...) ((void)0)
+      vsnprintf(buffer.get(), size, message, args);
 #endif
 
-/**
- * @brief Default logger for logging messages to stdout at the info level.
- * Output stream and logging level for the default logger can be globally
- * changed on a per-program basis.
- */
-static Logger kDefLog = {stdout, "", kInfo};
+      // Brackets and messages are white.
+      // Log levels are red for error and warning, orange for info, and grey for trace.
+      // Then the color is reset.
+      logger.stream << white << "[" << logColors[level] << kLevelStr[level] << white << "] ";
+      logger.stream << buffer.get();
+      logger.stream << reset << std::endl;
+      va_end(args);
+    }
+  }
+#else
+  template <typename... Args>
+  inline void LOG(Logger &logger, int level, const char *message, Args... args)
+  {
+    (void)logger;
+    (void)level;
+    (void)message;
+    (void)(std::initializer_list<int>{(static_cast<void>(args), 0)...});
+  }
+#endif
 
-/**
- * @brief Set the log level of the default logger.
- * @param level The log level to set.
- */
-void setLogLevel(int level) {
-  kDefLog.level = level;
-}
+  /**
+   * @brief Default logger for logging messages to stdout at the info level.
+   * Output stream and logging level for the default logger can be globally
+   * changed on a per-program basis.
+   */
+  static Logger kDefLog = {std::cout, kInfo};
+
+  /**
+   * @brief Set the log level of the default logger.
+   * @param level The log level to set.
+   */
+  static inline void setLogLevel(int level)
+  {
+    kDefLog.level = level;
+  }
 
 } // namespace gpu
 

--- a/utils/logging.h
+++ b/utils/logging.h
@@ -38,15 +38,15 @@ namespace gpu
     return oss.str();
   }
 
+/**
+ * @brief Log a message to the logger. If NO_LOG is defined in a source or as a
+ * compiler flag, this is a no-op.
+ *
+ * @param logger The logger to log to.
+ * @param level The log level of the message.
+ * @param message The message to log.
+ */
 #ifndef NO_LOG
-  /**
-   * @brief Log a message to the logger. If NDEBUG is defined in a source or as a
-   * compiler flag, this is a no-op.
-   *
-   * @param logger The logger to log to.
-   * @param level The log level of the message.
-   * @param message The message to log.
-   */
   template <typename... Args>
   inline void LOG(Logger &logger, int level, const char *message, ...)
   {


### PR DESCRIPTION
The way we were printing from LOG caused a crash when embedded on windows. This updates the logger to be more typesafe and generally compatible across platforms.

I removed exit(1) from the check function. We should never automatically exit the program as a library, this can prevent proper logging if there is indeed a crash.

Also introduces a NO_LOG definition that we should add throughout.

Also adds log level 0 for silent output.