### PR TITLE
Add metal_profiler to profile gpu on macos

### DIFF
--- a/examples/matmul/Makefile
+++ b/examples/matmul/Makefile
@@ -15,10 +15,20 @@ FLAGS=-std=c++17 $(STDLIB) -I$(GPUCPP) -I$(GPUCPP)/third_party/headers -L$(GPUCP
 run: ./build/$(TARGET)
 	$(LIBSPEC) && ./build/$(TARGET)
 
+run_with_metal_profiler: ./build/$(TARGET)_with_metal_profiler
+	$(LIBSPEC) && export METAL_CAPTURE_ENABLED=1 && ./build/$(TARGET)_with_metal_profiler
+
+run_with_time_profiler: ./build/$(TARGET)_with_metal_profiler
+	$(LIBSPEC) && xcrun xctrace record --template 'Time Profiler' --launch -- ./build/$(TARGET)_with_metal_profiler
+
 # Use clang -v to see the include paths
 # Note in this example optimization is turned on
 build/$(TARGET): run.cpp
 	mkdir -p build && $(CXX) $(FLAGS) -o ./build/$(TARGET)
+
+build/$(TARGET)_with_metal_profiler: run.cpp
+	mkdir -p build && $(CXX) $(FLAGS) -o ./build/$(TARGET)_with_metal_profiler $(GPUCPP)/experimental/profiler/metal.mm -framework metal -framework Foundation -DMETAL_PROFILER -g
+	install_name_tool -change @rpath/libdawn.dylib $(GPUCPP)/third_party/lib/libdawn.dylib ./build/$(TARGET)_with_metal_profiler
 
 watch: 
 	@command -v entr >/dev/null 2>&1 || { echo >&2 "Please install entr with 'brew install entr' or 'sudo apt-get install entr'"; exit 1; }

--- a/experimental/kernels/Makefile
+++ b/experimental/kernels/Makefile
@@ -32,6 +32,12 @@ default: run-native
 run_llm.c: ./build/test_gpt2 dawnlib
 	$(LIBSPEC) && $<
 
+run_llm.c_with_metal_profiler: ./build/test_gpt2_with_metal_profiler dawnlib
+	$(LIBSPEC) && export METAL_CAPTURE_ENABLED=1 && $<
+
+run_llm.c_with_time_profiler: ./build/test_gpt2_with_metal_profiler dawnlib
+	$(LIBSPEC) && xcrun xctrace record --template 'Time Profiler' --launch -- $<
+
 run_llm.c_train: ./build/train_gpt2 dawnlib
 	if [ ! -d dev ] ; then ln -s $(GPUCPP)/third_party/llm.c/dev ; fi
 	if [ ! -f gpt2_tokenizer.bin ] ; then ln -s $(GPUCPP)/third_party/llm.c/gpt2_tokenizer.bin ; fi
@@ -48,8 +54,9 @@ gpt2_124M.bin: llm.c
 					ln -s ./llm.c/gpt2_tokenizer.bin ; \
 	fi
 
-build/test_gpt2: llm.c build/unittest_kernels.o gpt2_124M.bin
-	mkdir -p build
+define preprocess_file
+	sed -i -e 's/int main(/int MAIN(/g' llm.c/test_gpt2.c
+	sed -i -e 's/int main(/int MAIN(/g' llm.c/train_gpt2.c
 	sed -i -e 's/void encoder_forward(/void ENCODER_FORWARD_CPU(/g' llm.c/train_gpt2.c
 	sed -i -e 's/void layernorm_forward(/void LAYERNORM_FORWARD_CPU(/g' llm.c/train_gpt2.c
 	sed -i -e 's/void matmul_forward(/void MATMUL_FORWARD_CPU(/g' llm.c/train_gpt2.c
@@ -67,26 +74,22 @@ build/test_gpt2: llm.c build/unittest_kernels.o gpt2_124M.bin
 	sed -i -e 's/void crossentropy_softmax_backward(/void CROSSENTROPY_SOFTMAX_BACKWARD_CPU(/g' llm.c/train_gpt2.c
 	grep -q "^#include \"unittest_kernels.h\"" llm.c/train_gpt2.c || \
 		printf '1i\n#include "unittest_kernels.h"\n.\nw\nq\n' | ed -s llm.c/train_gpt2.c
+endef
+
+build/test_gpt2: llm.c build/unittest_kernels.o gpt2_124M.bin
+	mkdir -p build
+	$(call preprocess_file)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ llm.c/test_gpt2.c build/unittest_kernels.o
+
+build/test_gpt2_with_metal_profiler: llm.c build/unittest_kernels.o gpt2_124M.bin
+	mkdir -p build
+	$(call preprocess_file)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ llm.c/test_gpt2.c build/unittest_kernels.o -I$(GPUCPP) $(GPUCPP)/experimental/profiler/metal.mm -framework metal -framework Foundation -DMETAL_PROFILER -g
+	install_name_tool -change @rpath/libdawn.dylib $(GPUCPP)/third_party/lib/libdawn.dylib $@
 
 build/train_gpt2: llm.c build/unittest_kernels.o gpt2_124M.bin
 	mkdir -p build
-	sed -i -e 's/void encoder_forward(/void ENCODER_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void layernorm_forward(/void LAYERNORM_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void matmul_forward(/void MATMUL_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void attention_forward(/void ATTENTION_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void gelu_forward(/void GELU_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void residual_forward(/void RESIDUAL_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void softmax_forward(/void SOFTMAX_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void crossentropy_forward(/void CROSSENTROPY_FORWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void encoder_backward(/void ENCODER_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void layernorm_backward(/void LAYERNORM_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void matmul_backward(/void MATMUL_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void attention_backward(/void ATTENTION_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void gelu_backward(/void GELU_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void residual_backward(/void RESIDUAL_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	sed -i -e 's/void crossentropy_softmax_backward(/void CROSSENTROPY_SOFTMAX_BACKWARD_CPU(/g' llm.c/train_gpt2.c
-	grep -q "^#include \"unittest_kernels.h\"" llm.c/train_gpt2.c || sed -i '1i#include \"unittest_kernels.h\"' llm.c/train_gpt2.c
+	$(call preprocess_file)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ llm.c/train_gpt2.c build/unittest_kernels.o
 
 build/ops.o: ops.cpp ops.hpp kernels.h llm.c

--- a/experimental/kernels/unittest_llmc/unittest_kernels.h
+++ b/experimental/kernels/unittest_llmc/unittest_kernels.h
@@ -2,6 +2,23 @@
 extern "C" {
 #endif
 
+#ifdef METAL_PROFILER
+#include "experimental/profiler/metal.hpp"
+
+#define MAIN main_wrapper
+static int main_wrapper(int argc, char *argv[]);
+
+int main(int argc, char *argv[]) {
+  startCapture();
+  int ret = main_wrapper(argc, argv);
+  stopCapture();
+  return ret;
+}
+
+#else
+#define MAIN main
+#endif
+
 // --  USE_GPU_FOR_* are the GPU/CPU switching flags for the kernels in llm.c. --
 
 #define USE_GPU_FOR_ENCODER_FORWARD 1

--- a/experimental/profiler/metal.hpp
+++ b/experimental/profiler/metal.hpp
@@ -1,0 +1,6 @@
+#ifdef __APPLE__
+extern "C" {
+  void startCapture();
+  void stopCapture();
+}
+#endif

--- a/experimental/profiler/metal.mm
+++ b/experimental/profiler/metal.mm
@@ -1,0 +1,46 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <QuartzCore/CAMetalLayer.h>
+
+
+extern "C" {
+  void startCapture() {
+    if (![[NSProcessInfo processInfo].environment[@"METAL_CAPTURE_ENABLED"] boolValue]) {
+      NSLog(@"METAL_CAPTURE_ENABLED is not set. Please set it to 1 to enable Metal capture.");
+      return;
+    }
+    
+    MTLCaptureDescriptor *descriptor = [[MTLCaptureDescriptor alloc] init];
+    descriptor.destination = MTLCaptureDestinationGPUTraceDocument;
+    descriptor.outputURL = [NSURL fileURLWithPath:@"gpu.cpp.gputrace"];
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:@"gpu.cpp.gputrace"]) {
+      NSError *error = nil;
+      [fileManager removeItemAtPath:@"gpu.cpp.gputrace" error:&error];
+      if (error) {
+        NSLog(@"Error deleting existing gpu.cpp.gputrace directory: %@", error);
+        return;
+      } else {
+        NSLog(@"Deleted existing gpu.cpp.gputrace directory.");
+      }
+    }
+
+    NSError *error = nil;
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if (!device) {
+      NSLog(@"MTLCreateSystemDefaultDevice returned nil. Metal may not be supported on this system.");
+      return;
+    }
+    descriptor.captureObject = device;
+    
+    BOOL success = [MTLCaptureManager.sharedCaptureManager startCaptureWithDescriptor:descriptor error:&error];
+    if (!success) {
+        NSLog(@" error capturing mtl => %@ ", [error localizedDescription] );
+    }
+  }
+
+  void stopCapture() {
+    [MTLCaptureManager.sharedCaptureManager stopCapture];
+  }
+}


### PR DESCRIPTION
This PR adds start/stopCapture functions to profile metal shader functions.

https://github.com/AnswerDotAI/gpu.cpp/issues/61

To call metal-functions on C++, we need to use objective-c++ or metal-cpp.
It simply provides C APIs using Objective-C.
