### PR TITLE
Some changes about the dynamic libraries generated by gpu.cpp project and header-only source code 'gpu.hpp'

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,32 @@
+# Dictionary of header files and their relative paths
+header_files = {
+    "#include \"webgpu/webgpu.h\"": "third_party/headers/webgpu/webgpu.h",
+    "#include \"numeric_types/half.hpp\"": "numeric_types/half.hpp",
+    "#include \"utils/logging.hpp\"": "utils/logging.hpp"
+}
+
+def main():
+    # File paths
+    source_file_path = "gpu.hpp"
+    output_file_path = "build/gpu.hpp"
+
+    # Open source file and read contents
+    with open(source_file_path, "r") as source:
+        file_contents = source.read()
+
+    # Ergodic over header files
+    for key, value in header_files.items():
+
+        # Replace header files
+        with open(value, "r") as header_file:
+            header_file_contents = header_file.read()
+        file_contents = file_contents.replace(key, header_file_contents)
+        
+
+    # Open output file
+    with open(output_file_path, "w") as output:
+        # Write contents to output file
+        output.write(file_contents)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
    feat: 1. Modified the 'lib' rule in the Makefile file located in the root directory of the project, allowing it to generate gpu.cpp dynamic libraries with different suffixes based on the system.
          2. By the build.py script, the header files in the gpu.hpp file are expanded in order to make gpu.hpp become true header-only source code.
          3. 'install' and 'uninstall' rules are provided for scientific researchers who do not care about how to package applications, enabling them to quickly utilize gpu.cpp for gpu computation.